### PR TITLE
Add logic for scoring transcript segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,20 @@ python3 -m src.examples.ollama_chat_example
 python3 -m src.examples.youtube_segments_example
 ```
 
+### YouTube Video Chunk Scoring
+```bash
+python3 -m src.examples.score_video_chunks_example
+```
+
 ## Project Structure
 ```
 clint/
 ├── src/
-│   ├── services/          # API clients (Twitch, YouTube)
+│   ├── services/          # API clients (Twitch, YouTube, LLM)
+│   │   ├── llm/           # LLM service and prompts
+│   │   ├── transcript_processor.py # Transcript extraction and segmentation
+│   │   ├── twitch_client.py
+│   │   └── youtube_client.py
 │   └── examples/          # Example scripts
 ```
 

--- a/src/examples/score_video_chunks_example.py
+++ b/src/examples/score_video_chunks_example.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Example script to score all chunks of a YouTube video and sort them by score.
+"""
+
+from ..services.youtube_client import YouTubeClient
+from ..services.llm.client import LLMClient, TranscriptScore
+
+
+def main():
+    youtube_client = YouTubeClient()
+
+    # Get video URL from user
+    video_url = input("Enter YouTube video URL: ").strip()
+    if not video_url:
+        print("Error: URL cannot be empty.")
+        return
+
+    print(f"\n🎬 Processing video: {video_url}")
+    print("=" * 60)
+
+    # Get video info first
+    print("📊 Getting video information...")
+    video_info = youtube_client.get_video_info(video_url)
+    if video_info:
+        print(f"Title: {video_info['title']}")
+        print(f"Duration: {video_info['duration']} seconds")
+        print(f"Uploader: {video_info['uploader']}")
+    else:
+        print("Could not get video info")
+
+    # Get transcript with 60-second segments
+    print(f"\n📝 Extracting transcript with 60-second segments...")
+    result = youtube_client.get_transcript_with_segments(video_url, segment_seconds=60)
+
+    if not result.transcript_result.success:
+        print(f"❌ Failed to get transcript: {result.transcript_result.error_message}")
+        return
+
+    print(f"✅ Found {len(result.segments)} segments")
+    print(f"📄 Full transcript length: {len(result.transcript_result.transcript)} characters")
+    print(f"⏱️  Extraction took: {result.transcript_result.duration:.2f} seconds")
+
+    # Score each segment
+    print(f"\n🤖 Scoring all {len(result.segments)} segments...")
+    print("=" * 60)
+
+    scored_segments = []
+    total_scoring_time = 0
+
+    for i, segment in enumerate(result.segments):
+        # Combine all text from segment lines
+        segment_text = " ".join([line.text for line in segment.lines])
+        
+        # Score the segment
+        score: TranscriptScore = LLMClient.score_transcript(segment_text)
+        
+        if score is None:
+            print(f"  ❌ Failed to score segment {i+1}")
+            continue
+
+        # Store segment with its score and metadata
+        scored_segments.append({
+            'segment_index': i,
+            'start_time': segment.start,
+            'end_time': segment.end,
+            'text': segment_text[:100] + "..." if len(segment_text) > 100 else segment_text,
+            'score': score,
+            'overall_score': score.overall
+        })
+
+        total_scoring_time += score.scoring_duration
+        print(f"  ✅ Segment {i+1}: {score.overall}/100 (took {score.scoring_duration:.2f}s)")
+
+    if not scored_segments:
+        print("❌ No segments were successfully scored.")
+        return
+
+    # Sort segments by overall score (highest first)
+    scored_segments.sort(key=lambda x: x['overall_score'], reverse=True)
+
+    # Display results
+    print(f"\n🏆 TOP SCORING SEGMENTS (sorted by overall score):")
+    print("=" * 60)
+    print(f"📊 Total scoring time: {total_scoring_time:.2f} seconds")
+    print(f"📈 Average scoring time per segment: {total_scoring_time/len(scored_segments):.2f} seconds")
+    print()
+
+    for i, segment_data in enumerate(scored_segments):
+        score = segment_data['score']
+        print(f"🥇 #{i+1} - Segment {segment_data['segment_index']+1}")
+        print(f"   ⏰ Time: {segment_data['start_time']:.1f}s - {segment_data['end_time']:.1f}s")
+        print(f"   📊 Overall: {score.overall}/100")
+        print(f"   📝 Clarity: {score.clarity}/100")
+        print(f"   🏗️  Structure: {score.structure}/100")
+        print(f"   💡 Informativeness: {score.informativeness}/100")
+        print(f"   🎯 Engagement: {score.engagement}/100")
+        print(f"   ⚡ Pacing: {score.pacing}/100")
+        print(f"   💭 Rationale: {score.rationale}")
+        print(f"   📄 Text: {segment_data['text']}")
+        print("-" * 60)
+
+    # Summary statistics
+    if scored_segments:
+        scores = [s['overall_score'] for s in scored_segments]
+        print(f"\n📈 SCORE STATISTICS:")
+        print(f"   🎯 Highest score: {max(scores)}/100")
+        print(f"   📉 Lowest score: {min(scores)}/100")
+        print(f"   📊 Average score: {sum(scores)/len(scores):.1f}/100")
+        print(f"   📊 Median score: {sorted(scores)[len(scores)//2]}/100")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -2,6 +2,12 @@
 # This file makes the services directory a Python package
 
 from .twitch_client import TwitchClient
-from .youtube_client import YouTubeClient, TranscriptResult
+from .youtube_client import YouTubeClient, TranscriptResult, TranscriptWithSegmentsResult
+from .transcript_processor import TranscriptProcessor, TranscriptLine, TranscriptSegment
+from .llm.client import LLMClient, TranscriptScore, ViralScore, ScoredChunk, ScoredChunksResult
 
-__all__ = ['TwitchClient', 'YouTubeClient', 'TranscriptResult']
+__all__ = [
+    'TwitchClient', 'YouTubeClient', 'TranscriptResult', 'TranscriptWithSegmentsResult',
+    'TranscriptProcessor', 'TranscriptLine', 'TranscriptSegment',
+    'LLMClient', 'TranscriptScore', 'ViralScore', 'ScoredChunk', 'ScoredChunksResult'
+]

--- a/src/services/llm/__init__.py
+++ b/src/services/llm/__init__.py
@@ -1,0 +1,3 @@
+# LLM service package
+
+

--- a/src/services/llm/client.py
+++ b/src/services/llm/client.py
@@ -1,0 +1,245 @@
+"""
+LLM Client built on top of Ollama for prompting tasks.
+"""
+
+from typing import Optional, List, Dict, Any
+import json
+import ollama
+import time
+import re
+from dataclasses import dataclass
+
+from .prompts import SCORE_TRANSCRIPT_SYSTEM, SCORE_TRANSCRIPT_USER
+
+
+@dataclass
+class TranscriptScore:
+    """
+    Structured result for transcript scoring.
+    """
+    overall: float
+    clarity: float
+    structure: float
+    informativeness: float
+    engagement: float
+    pacing: float
+    rationale: str
+    original_segment: str
+    scoring_duration: float  # Time taken to score in seconds
+
+
+@dataclass
+class ViralScore:
+    """
+    Structured result for viral potential scoring.
+    """
+    score: int
+    reason: str
+    hookline: str
+    tags: list[str]
+    summary: str
+
+
+@dataclass
+class ScoredChunk:
+    """
+    A chunk of transcript with its score and metadata.
+    """
+    chunk_index: int
+    start_char: int
+    end_char: int
+    text: str
+    score: TranscriptScore
+    overall_score: float
+
+
+@dataclass
+class ScoredChunksResult:
+    """
+    Result containing all scored chunks sorted by score.
+    """
+    chunks: List[ScoredChunk]
+    total_chunks: int
+    total_scoring_time: float
+    average_score: float
+    highest_score: float
+    lowest_score: float
+
+
+class LLMClient:
+    """
+    Minimal LLM client wrapper (Ollama) for common prompting tasks.
+    """
+
+    @staticmethod
+    def score_transcript(transcript: str, model: str = "llama3.1:8b") -> Optional[TranscriptScore]:
+        """
+        Score a transcript and return a structured TranscriptScore object.
+
+        Returns None if parsing fails or model unavailable.
+        """
+        if not transcript or not transcript.strip():
+            return None
+
+        start_time = time.time()
+        
+        messages = [
+            {"role": "system", "content": SCORE_TRANSCRIPT_SYSTEM},
+            {"role": "user", "content": SCORE_TRANSCRIPT_USER.format(transcript=transcript[:15000])},
+        ]
+
+        try:
+            resp = ollama.chat(model=model, messages=messages)
+            content = resp["message"]["content"]
+            
+            # Best-effort JSON extraction
+            content = content.strip()
+            if not content:
+                print("[DEBUG] Empty response from LLM")
+                return None
+                
+            # Attempt to locate a JSON object if there's extra text
+            start = content.find("{")
+            end = content.rfind("}")
+            if start != -1 and end != -1 and end > start:
+                content = content[start:end+1]
+            else:
+                return None
+                
+            data = json.loads(content)
+            
+            # Calculate duration
+            end_time = time.time()
+            duration = end_time - start_time
+            
+            # Convert to TranscriptScore dataclass
+            return TranscriptScore(
+                overall=float(data.get("overall", 0)),
+                clarity=float(data.get("clarity", 0)),
+                structure=float(data.get("structure", 0)),
+                informativeness=float(data.get("informativeness", 0)),
+                engagement=float(data.get("engagement", 0)),
+                pacing=float(data.get("pacing", 0)),
+                rationale=str(data.get("rationale", "")),
+                original_segment=transcript,
+                scoring_duration=duration
+            )
+        except Exception as e:
+            print(f"Scoring transcript failed: {e}")
+            return None
+
+    @staticmethod
+    def score_transcript_chunks(transcript: str, chunk_size: int = 1000, overlap: int = 100, model: str = "llama3.1:8b") -> Optional[ScoredChunksResult]:
+        """
+        Break a transcript into chunks, score each chunk, and return sorted results.
+        
+        Args:
+            transcript: The full transcript text to chunk and score
+            chunk_size: Maximum characters per chunk (default: 1000)
+            overlap: Number of characters to overlap between chunks (default: 100)
+            
+        Returns:
+            ScoredChunksResult: Sorted chunks with scores and statistics
+        """
+        if not transcript or not transcript.strip():
+            return None
+            
+        # Break transcript into chunks
+        chunks = LLMClient._create_chunks(transcript, chunk_size, overlap)
+        
+        if not chunks:
+            return None
+            
+        # Score each chunk
+        scored_chunks = []
+        total_scoring_time = 0.0
+        
+        for i, (start_char, end_char, chunk_text) in enumerate(chunks):
+            if not chunk_text.strip():
+                continue
+                
+            # Score the chunk
+            score = LLMClient.score_transcript(chunk_text, model)
+            
+            if score is None:
+                continue
+                
+            # Create scored chunk
+            scored_chunk = ScoredChunk(
+                chunk_index=i,
+                start_char=start_char,
+                end_char=end_char,
+                text=chunk_text,
+                score=score,
+                overall_score=score.overall
+            )
+            
+            scored_chunks.append(scored_chunk)
+            total_scoring_time += score.scoring_duration
+        
+        if not scored_chunks:
+            return None
+            
+        # Sort by overall score (highest first)
+        scored_chunks.sort(key=lambda x: x.overall_score, reverse=True)
+        
+        # Calculate statistics
+        scores = [chunk.overall_score for chunk in scored_chunks]
+        average_score = sum(scores) / len(scores) if scores else 0.0
+        highest_score = max(scores) if scores else 0.0
+        lowest_score = min(scores) if scores else 0.0
+        
+        return ScoredChunksResult(
+            chunks=scored_chunks,
+            total_chunks=len(scored_chunks),
+            total_scoring_time=total_scoring_time,
+            average_score=average_score,
+            highest_score=highest_score,
+            lowest_score=lowest_score
+        )
+    
+    @staticmethod
+    def _create_chunks(text: str, chunk_size: int, overlap: int) -> List[tuple[int, int, str]]:
+        """
+        Break text into overlapping chunks.
+        
+        Args:
+            text: Text to chunk
+            chunk_size: Maximum characters per chunk
+            overlap: Characters to overlap between chunks
+            
+        Returns:
+            List of (start_char, end_char, chunk_text) tuples
+        """
+        chunks = []
+        start = 0
+        
+        while start < len(text):
+            # Find the end position for this chunk
+            end = min(start + chunk_size, len(text))
+            
+            # Try to break at sentence boundaries if possible
+            if end < len(text):
+                # Look for sentence endings within the last 100 characters
+                search_start = max(start, end - 100)
+                sentence_endings = ['.', '!', '?', '\n']
+                
+                for i in range(end - 1, search_start - 1, -1):
+                    if text[i] in sentence_endings:
+                        end = i + 1
+                        break
+            
+            chunk_text = text[start:end].strip()
+            if chunk_text:
+                chunks.append((start, end, chunk_text))
+            
+            # Move start position with overlap
+            start = max(start + 1, end - overlap)
+            
+            # Prevent infinite loop
+            if start >= end:
+                start = end
+        
+        return chunks
+
+

--- a/src/services/llm/prompts.py
+++ b/src/services/llm/prompts.py
@@ -1,0 +1,36 @@
+"""
+Prompt templates for the LLM service.
+"""
+
+SCORE_TRANSCRIPT_SYSTEM = (
+    "You are a helpful assistant that evaluates YouTube video transcripts. "
+    "Analyze for clarity, structure, informativeness, engagement, and pacing. "
+    "Return a concise JSON object with numeric scores (0-100) and a short rationale."
+)
+
+SCORE_TRANSCRIPT_USER = (
+    """
+    You evaluate a single podcast transcript segment for VIRAL short-form potential (TikTok, YouTube Shorts, Reels).
+    
+    Rules:
+    - Score only this segment (not the whole episode).
+    - Favor surprising or contrarian claims, emotionally charged or controversial takes, unique insights, crisp story beats, quotable lines, and curiosity hooks.
+    - Reward segments that would make a scroller pause in the first 3–5 seconds.
+    - Penalize vague filler, meandering setup with no payoff, overly technical detail with no hook, or low-stakes chatter.
+    - Keep outputs concise and strictly valid JSON.
+
+    Output schema (STRICT JSON only):
+    {{
+    "overall": <number 0-100>,              // Overall viral potential score
+    "clarity": <number 0-100>,             // How clear and understandable the content is
+    "structure": <number 0-100>,            // How well-organized and logical the flow is
+    "informativeness": <number 0-100>,     // How valuable and informative the content is
+    "engagement": <number 0-100>,           // How engaging and attention-grabbing it is
+    "pacing": <number 0-100>,             // How well-paced and dynamic the delivery is
+    "rationale": "<<=150 chars explanation>>"  // Brief explanation of the scoring
+    }}
+
+
+    Transcript:\n\n{transcript}
+    """
+)


### PR DESCRIPTION
## Summary
* This PR adds the logic needed for scoring each individual video segment based on the transcript

## Test Plan
* Ran `python3 -m src.examples.score_video_chunks_example` and entered a `YouTube` video link
* Saw scored segments and viewed video

| Result
|---
| <img width="1451" height="808" alt="image" src="https://github.com/user-attachments/assets/c3594a44-08ff-4fdf-a0e1-5df62f61f767" />
